### PR TITLE
Add support for button-based charger start/stop (ABB Terra AC)

### DIFF
--- a/custom_components/evsci/config_flow.py
+++ b/custom_components/evsci/config_flow.py
@@ -119,7 +119,7 @@ class EVSCIConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # --- OBVEZNI SENZORJI POLNILNICE ---
             vol.Required(CONF_CHARGER_SWITCH): selector.EntitySelector(
                 selector.EntitySelectorConfig(
-                    domain="switch",
+                    domain=["switch", "button"],
                 )
             ),
             vol.Required(CONF_CHARGER_CURRENT): selector.EntitySelector(
@@ -286,7 +286,12 @@ class EVSCIConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Definiraj vzorce iskanja za vsak tip polnilnice
         search_patterns = {
             "abb_terra": {
-                "switch": ["switch.*abb*start*stop*", "switch.*abb*charging"],
+                "switch": [
+                    "button.*abb*start*charging*",
+                    "button.*abb*start*",
+                    "switch.*abb*start*stop*",
+                    "switch.*abb*charging",
+                ],
                 "current": ["number.*abb*current*limit"],
                 "power": ["sensor.*abb*active*power", "sensor.*abb*power"],
                 "status": ["sensor.*abb*charging*state", "sensor.*abb*state"],
@@ -468,7 +473,7 @@ class EVSCIOptionsFlowHandler(config_entries.OptionsFlow):
             
             # Entitete polnilnice
             vol.Required(CONF_CHARGER_SWITCH): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="switch")
+                selector.EntitySelectorConfig(domain=["switch", "button"])
             ),
             vol.Required(CONF_CHARGER_CURRENT): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain=["number", "select"])

--- a/custom_components/evsci/coordinator.py
+++ b/custom_components/evsci/coordinator.py
@@ -194,6 +194,58 @@ class EVSCICoordinator(DataUpdateCoordinator):
             5: o.get(CONF_LIMIT_BLOCK_5, d.get(CONF_LIMIT_BLOCK_5, 6000)),
         }
 
+    def _resolve_stop_button_entity(self) -> str | None:
+        """Resolve stop-button entity from configured start-button entity."""
+        if not self.charger_switch_entity or not self.charger_switch_entity.startswith("button."):
+            return None
+
+        start_entity = self.charger_switch_entity
+        if "start_charging" in start_entity:
+            return start_entity.replace("start_charging", "stop_charging")
+        if "start" in start_entity:
+            return start_entity.replace("start", "stop", 1)
+        return None
+
+    async def _async_start_session(self) -> None:
+        """Start charging session for switch- and button-based chargers."""
+        if self.charger_switch_entity.startswith("button."):
+            await self.hass.services.async_call(
+                "button",
+                "press",
+                {ATTR_ENTITY_ID: self.charger_switch_entity},
+            )
+            return
+
+        await self.hass.services.async_call(
+            "switch",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: self.charger_switch_entity},
+        )
+
+    async def _async_stop_session(self) -> None:
+        """Stop charging session for switch- and button-based chargers."""
+        if self.charger_switch_entity.startswith("button."):
+            stop_button_entity = self._resolve_stop_button_entity()
+            if stop_button_entity:
+                await self.hass.services.async_call(
+                    "button",
+                    "press",
+                    {ATTR_ENTITY_ID: stop_button_entity},
+                )
+            else:
+                _LOGGER.warning(
+                    "EVSCI: Charger control entity is button-based, but stop button "
+                    "could not be inferred from '%s'.",
+                    self.charger_switch_entity,
+                )
+            return
+
+        await self.hass.services.async_call(
+            "switch",
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: self.charger_switch_entity},
+        )
+
     def _get_grid_power(self):
         """Enhanced grid power reading with template support and inversion."""
         if self.use_grid_template and self._grid_template:
@@ -599,11 +651,7 @@ class EVSCICoordinator(DataUpdateCoordinator):
         if should_be_active and not self.is_charging:
             if target_amps > 0:
                 _LOGGER.info("EVSCI: Start Session (Switch ON)")
-                await self.hass.services.async_call(
-                    "switch",
-                    SERVICE_TURN_ON,
-                    {ATTR_ENTITY_ID: self.charger_switch_entity}
-                )
+                await self._async_start_session()
                 if target_amps > 0:
                     await asyncio.sleep(1)
                     target_value = self._convert_amps_to_current(target_amps)
@@ -619,11 +667,7 @@ class EVSCICoordinator(DataUpdateCoordinator):
         elif not should_be_active and self.is_charging:
             if self._cable_connected:
                 _LOGGER.info("EVSCI: End Session (Switch OFF)")
-                await self.hass.services.async_call(
-                    "switch",
-                    SERVICE_TURN_OFF,
-                    {ATTR_ENTITY_ID: self.charger_switch_entity}
-                )
+                await self._async_stop_session()
             else:
                 _LOGGER.debug("EVSCI: Session inactive, cable unplugged. Skip switch OFF.")
 

--- a/custom_components/evsci/strings.json
+++ b/custom_components/evsci/strings.json
@@ -12,7 +12,7 @@
         "title": "Charger Configuration",
         "description": "Select your charger entities. Status values are automatically set based on the selected type.",
         "data": {
-          "charger_switch": "Charger Switch",
+          "charger_switch": "Charger Control",
           "charger_current": "Current Setting (A)",
           "charger_power": "Charger Power Sensor (W)",
           "charger_status": "Charger Status (for plug detection)",
@@ -22,7 +22,7 @@
           "status_connected_values": "Status Values - Connected"
         },
         "data_description": {
-          "charger_switch": "Entity to turn charging on/off (e.g., switch.abb_start_stop_charging)",
+          "charger_switch": "Entity to start charging (switch or button, e.g., button.abb_start_charging)",
           "charger_current": "Entity to set current in amperes (e.g., number.abb_charging_current_limit)",
           "charger_power": "Current charging power sensor in watts (e.g., sensor.abb_active_power)",
           "charger_status": "Charger status sensor used to detect cable connection (e.g., sensor.abb_charging_state)",
@@ -88,7 +88,6 @@
       "invalid_auth": "Invalid authentication",
       "unknown": "Unknown error",
       "grid_template_required": "Template code is required when template mode is enabled"
-      "unknown": "Unknown error"
     },
     "abort": {
       "already_configured": "Device already configured"
@@ -101,7 +100,7 @@
         "description": "Here you can change limits and sensors.",
         "data": {
           "charger_type": "Charger Type",
-          "charger_switch": "Charger Switch",
+          "charger_switch": "Charger Control",
           "charger_current": "Current Setting (A)",
           "charger_power": "Charger Power Sensor (W)",
           "charger_status": "Charger Status (for plug detection)",
@@ -129,7 +128,7 @@
         },
         "data_description": {
           "charger_type": "Your charger type (for correct presets)",
-          "charger_switch": "Entity to turn charging on/off",
+          "charger_switch": "Entity used to start charging (switch or button). For button-based chargers, EVSCI auto-detects a matching stop button.",
           "charger_current": "Entity to set current in amperes",
           "charger_power": "Current charging power sensor in watts",
           "charger_status": "Charger status sensor for cable detection",

--- a/custom_components/evsci/translations/en.json
+++ b/custom_components/evsci/translations/en.json
@@ -12,7 +12,7 @@
         "title": "Charger Configuration",
         "description": "Select your charger entities. Status values are automatically set based on the selected type.",
         "data": {
-          "charger_switch": "Charger Switch",
+          "charger_switch": "Charger Control",
           "charger_current": "Current Setting (A)",
           "charger_power": "Charger Power Sensor (W)",
           "charger_status": "Charger Status (for plug detection)",
@@ -22,7 +22,7 @@
           "status_connected_values": "Status Values - Connected"
         },
         "data_description": {
-          "charger_switch": "Entity to turn charging on/off (e.g., switch.abb_start_stop_charging)",
+          "charger_switch": "Entity to start charging (switch or button, e.g., button.abb_start_charging)",
           "charger_current": "Entity to set current in amperes (e.g., number.abb_charging_current_limit)",
           "charger_power": "Current charging power sensor in watts (e.g., sensor.abb_active_power)",
           "charger_status": "Charger status sensor used to detect cable connection (e.g., sensor.abb_charging_state)",
@@ -100,7 +100,7 @@
         "description": "Here you can change limits and sensors.",
         "data": {
           "charger_type": "Charger Type",
-          "charger_switch": "Charger Switch",
+          "charger_switch": "Charger Control",
           "charger_current": "Current Setting (A)",
           "charger_power": "Charger Power Sensor (W)",
           "charger_status": "Charger Status (for plug detection)",
@@ -128,7 +128,7 @@
         },
         "data_description": {
           "charger_type": "Your charger type (for correct presets)",
-          "charger_switch": "Entity to turn charging on/off",
+          "charger_switch": "Entity used to start charging (switch or button). For button-based chargers, EVSCI auto-detects a matching stop button.",
           "charger_current": "Entity to set current in amperes",
           "charger_power": "Current charging power sensor in watts",
           "charger_status": "Charger status sensor for cable detection",

--- a/custom_components/evsci/translations/sl.json
+++ b/custom_components/evsci/translations/sl.json
@@ -12,7 +12,7 @@
         "title": "Konfiguracija polnilnice",
         "description": "Izberite entitete vaše polnilnice. Status vrednosti so avtomatsko nastavljene glede na izbran tip.",
         "data": {
-          "charger_switch": "Stikalo polnilnice",
+          "charger_switch": "Krmiljenje polnilnice",
           "charger_current": "Nastavitev toka (A)",
           "charger_power": "Senzor moči polnilnice (W)",
           "charger_status": "Status polnilnice (za zaznavo priklopa)",
@@ -22,7 +22,7 @@
           "status_connected_values": "Vrednosti statusa - priključeno"
         },
         "data_description": {
-          "charger_switch": "Entiteta za vklop/izklop polnjenja (npr. switch.abb_start_stop_charging)",
+          "charger_switch": "Entiteta za zagon polnjenja (switch ali button, npr. button.abb_start_charging)",
           "charger_current": "Entiteta za nastavitev toka v amperih (npr. number.abb_charging_current_limit)",
           "charger_power": "Senzor trenutne moči polnjenja v wattih (npr. sensor.abb_active_power)",
           "charger_status": "Senzor stanja polnilnice, uporabljen za zaznavanje priklopa kabla (npr. sensor.abb_charging_state)",
@@ -100,7 +100,7 @@
         "description": "Tukaj lahko spremenite limite in senzorje.",
         "data": {
           "charger_type": "Tip polnilnice",
-          "charger_switch": "Stikalo polnilnice",
+          "charger_switch": "Krmiljenje polnilnice",
           "charger_current": "Nastavitev toka (A)",
           "charger_power": "Senzor moči polnilnice (W)",
           "charger_status": "Status polnilnice (za zaznavo priklopa)",
@@ -128,7 +128,7 @@
         },
         "data_description": {
           "charger_type": "Tip vaše polnilnice (za pravilne prednastavitve)",
-          "charger_switch": "Entiteta za vklop/izklop polnjenja",
+          "charger_switch": "Entiteta za zagon polnjenja (switch ali button). Pri button polnilnicah EVSCI poskusi samodejno najti pripadajoč stop button.",
           "charger_current": "Entiteta za nastavitev toka v amperih",
           "charger_power": "Senzor trenutne moči polnjenja v wattih",
           "charger_status": "Senzor stanja polnilnice za zaznavanje priklopa kabla",


### PR DESCRIPTION
### Motivation
- Support chargers that use `button` entities for starting/stopping charging sessions (ABB Terra AC uses this pattern) instead of the previous `switch`-based control.
- Allow the config flow and auto-discovery to accept button-based control entities so users can configure ABB Terra and similar chargers more easily.
- Update UI text to clarify that the charger control may be a `switch` or `button` and fix a JSON syntax issue in the strings file.

### Description
- Added `_resolve_stop_button_entity`, `_async_start_session`, and `_async_stop_session` helper methods in `custom_components/evsci/coordinator.py` to handle `button.press` for button-based start/stop and to infer a matching stop button from the configured start entity.
- Switched start/stop invocation in `_apply_changes` to use the new `await self._async_start_session()` and `await self._async_stop_session()` helpers so existing `switch` behavior is preserved and `button` behavior is supported.
- Updated `custom_components/evsci/config_flow.py` selectors to accept `domain=["switch", "button"]` for the charger control entity and extended ABB Terra auto-discovery patterns to prioritize button-style start entities.
- Updated UI strings in `custom_components/evsci/strings.json`, `custom_components/evsci/translations/en.json`, and `custom_components/evsci/translations/sl.json` to describe the charger control as "switch or button" and added a note about automatic stop-button detection, and fixed an invalid JSON entry in `strings.json`.

### Testing
- Ran `python -m compileall custom_components/evsci` and compilation completed successfully.
- Verified JSON parsing with `json.load` for `custom_components/evsci/translations/en.json`, `custom_components/evsci/translations/sl.json`, and `custom_components/evsci/strings.json`, and all three files parsed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb371a8dc83209e77adb6db9b2922)